### PR TITLE
fix check for spline knots (over age and year)

### DIFF
--- a/R/popReconstruct_settings.R
+++ b/R/popReconstruct_settings.R
@@ -70,7 +70,7 @@ create_optional_settings <- function(settings, inputs, data = NULL) {
       setting_value <- settings[[setting_name]]
       assertthat::assert_that(
         assertive::is_numeric(setting_value),
-        setting_value %in% settings$years,
+        all(setting_value %in% settings$years),
         msg = paste0("setting '", setting_name, "' must be a numeric ",
                      "corresponding to the start of calendar year intervals ",
                      "as specified in the setting 'years'")
@@ -95,7 +95,7 @@ create_optional_settings <- function(settings, inputs, data = NULL) {
 
       assertthat::assert_that(
         assertive::is_numeric(setting_value),
-        setting_value %in% settings$expected_ages,
+        all(setting_value %in% expected_ages),
         msg = paste0("setting '", setting_name, "' must be a numeric ",
                      "corresponding to the start of age-group intervals ",
                      "as specified in the setting 'ages' or ",


### PR DESCRIPTION
## Describe changes

Quick bugfix where when specifying spline knots for popReconstruct the assertion breaks because its not evaluating to a single logical

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [ ] Have you successfully run `devtools::check()` locally?
* [ ] Have you added in tests for the changes included in the PR? 
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do your changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
