### PR TITLE
in stan model remove extra dimension for optional parameters

### DIFF
--- a/R/popReconstruct_draws.R
+++ b/R/popReconstruct_draws.R
@@ -117,7 +117,7 @@ extract_stan_draws <- function(fit, inputs, settings, detailed_settings) {
       # add on id variables to draws
       component_draws[, parameter := gsub(paste0("^", param, "|\\[|\\]"), "", parameter)]
       optional_params <- c("mx", "non_terminal_ax", "terminal_ax", "immigration", "emigration")
-      component_draws[, c(if (grepl("^offset", param) | param %in% optional_params) "estimate",
+      component_draws[, c(if (grepl("^offset", param)) "estimate",
                           if (!is.null(sexes)) "sex_index", "age_index", "year_index") :=
                         data.table::tstrsplit(parameter, split = ",")]
       assertthat::assert_that(

--- a/inst/stan/popReconstruct.stan
+++ b/inst/stan/popReconstruct.stan
@@ -290,17 +290,17 @@ transformed parameters {
   matrix[A, Y] spline_offset_log_emigration[sexes] = rep_array(rep_matrix(0, A, Y), sexes);
 
   // untransformed ccmpp input parameters
-  matrix<lower = 0>[1, Y] srb;
-  matrix<lower = 0>[A_f, Y] asfr;
-  matrix<lower = 0>[A, 1] baseline[sexes];
-  matrix<lower = 0, upper = 1>[A + 1, Y] survival[sexes];
-  matrix<lower = 0>[A + 1, Y] mx[estimate_mx, sexes];
-  matrix<lower = 0, upper = interval>[A, Y] non_terminal_ax[estimate_non_terminal_ax, sexes];
-  matrix<lower = 0>[1, Y] terminal_ax[estimate_terminal_ax, sexes];
-  matrix<lower = 0>[A + 1, Y] ax[estimate_non_terminal_ax, sexes];
-  matrix[A, Y] net_migration[sexes];
-  matrix<lower = 0>[A, Y] immigration[estimate_immigration, sexes];
-  matrix<lower = 0>[A, Y] emigration[estimate_emigration, sexes];
+  matrix<lower = 0>[1, Y] srb = rep_matrix(0, 1, Y);
+  matrix<lower = 0>[A_f, Y] asfr = rep_matrix(0, A_f, Y);
+  matrix<lower = 0>[A, 1] baseline[sexes] = rep_array(rep_matrix(0, A, 1), sexes);
+  matrix<lower = 0, upper = 1>[A + 1, Y] survival[sexes] = rep_array(rep_matrix(0, A + 1, Y), sexes);
+  matrix<lower = 0>[A + 1, Y] mx[sexes] = rep_array(rep_matrix(0, A + 1, Y), sexes);
+  matrix<lower = 0, upper = interval>[A, Y] non_terminal_ax[sexes] = rep_array(rep_matrix(0, A, Y), sexes);
+  matrix<lower = 0>[1, Y] terminal_ax[sexes] = rep_array(rep_matrix(0, 1, Y), sexes);
+  matrix<lower = 0>[A + 1, Y] ax[sexes] = rep_array(rep_matrix(0, A + 1, Y), sexes);
+  matrix[A, Y] net_migration[sexes] = rep_array(rep_matrix(0, A, Y), sexes);
+  matrix<lower = 0>[A, Y] immigration[sexes] = rep_array(rep_matrix(0, A, Y), sexes);
+  matrix<lower = 0>[A, Y] emigration[sexes] = rep_array(rep_matrix(0, A, Y), sexes);
 
   // calculate spline offsets
   if (estimate_srb) {
@@ -344,18 +344,19 @@ transformed parameters {
     if (estimate_survival) {
       survival[s] = inv_logit(input_logit_survival[s] + spline_offset_logit_survival[s]);
     } else {
-      mx[estimate_mx, s] = exp(input_log_mx[s] + spline_offset_log_mx[s]);
-      non_terminal_ax[estimate_non_terminal_ax, s] = bounded_inv_logit(input_bounded_logit_non_terminal_ax[s] + spline_offset_bounded_logit_non_terminal_ax[s], 0, interval);
-      terminal_ax[estimate_terminal_ax, s] = exp(input_log_terminal_ax[s] + spline_offset_log_terminal_ax[s]);
-      ax[estimate_non_terminal_ax, s] = append_row(non_terminal_ax[estimate_non_terminal_ax, s], terminal_ax[estimate_terminal_ax, s]);
-      survival[s] = calculate_nSx(mx[estimate_mx, s], ax[estimate_non_terminal_ax, s], interval, A, Y);
+
+      mx[s] = exp(input_log_mx[s] + spline_offset_log_mx[s]);
+      non_terminal_ax[s] = bounded_inv_logit(input_bounded_logit_non_terminal_ax[s] + spline_offset_bounded_logit_non_terminal_ax[s], 0, interval);
+      terminal_ax[s] = exp(input_log_terminal_ax[s] + spline_offset_log_terminal_ax[s]);
+      ax[s] = append_row(non_terminal_ax[s], terminal_ax[s]);
+      survival[s] = calculate_nSx(mx[s], ax[s], interval, A, Y);
     }
     if (estimate_net_migration) {
       net_migration[s] = input_net_migration[s] + spline_offset_net_migration[s];
     } else {
-      immigration[estimate_immigration, s] = exp(input_log_immigration[s] + spline_offset_log_immigration[s]);
-      emigration[estimate_emigration, s] = exp(input_log_emigration[s] + spline_offset_log_emigration[s]);
-      net_migration[s] = immigration[estimate_immigration, s] - emigration[estimate_emigration, s];
+      immigration[s] = exp(input_log_immigration[s] + spline_offset_log_immigration[s]);
+      emigration[s] = exp(input_log_emigration[s] + spline_offset_log_emigration[s]);
+      net_migration[s] = immigration[s] - emigration[s];
     }
   }
 


### PR DESCRIPTION
## Describe changes

Small PR to fix the test where mx is estimated but ax is fixed. 

Previously in the stan code there was an extra dimension `estimate_` added to the ccmpp input parameters that was either 0 or 1, 0 when the component was not being estimated. But this extra dimension actually isn't needed since the spline offset will be set to 0 if the component is fixed and the component will just be equal to its input value.

## What issues are related

Related to #21 

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [X] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [X] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [ ] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.