### PR TITLE
add 'mx' and 'ax' estimation flexibility to tmb model

### DIFF
--- a/R/popReconstruct_draws.R
+++ b/R/popReconstruct_draws.R
@@ -175,11 +175,18 @@ extract_stan_draws <- function(fit, inputs, settings, detailed_settings) {
     }
     # add on the 'age_end' column
     if ("age_start" %in% id_cols) {
+      if (comp == "asfr") {
+        right_most_age <- max(settings$ages_asfr) + settings$int
+      } else if (comp == "non_terminal_ax") {
+        right_most_age <- max(settings$ages_mortality)
+      } else {
+        right_most_age <- Inf
+      }
       hierarchyUtils::gen_end(
         dt = component_draws,
         id_cols = non_end_id_cols,
         col_stem = "age",
-        right_most_endpoint = ifelse(comp == "asfr", max(ages) + int, Inf)
+        right_most_endpoint = right_most_age
       )
     }
 
@@ -380,11 +387,18 @@ extract_tmb_draws <- function(fit, inputs, value_col, settings, detailed_setting
     }
     # add on the 'age_end' column
     if ("age_start" %in% id_cols) {
+      if (comp == "asfr") {
+        right_most_age <- max(settings$ages_asfr) + settings$int
+      } else if (comp == "non_terminal_ax") {
+        right_most_age <- max(settings$ages_mortality)
+      } else {
+        right_most_age <- Inf
+      }
       hierarchyUtils::gen_end(
         dt = component_draws,
         id_cols = non_end_id_cols,
         col_stem = "age",
-        right_most_endpoint = ifelse(comp == "asfr", max(ages) + int, Inf)
+        right_most_endpoint = right_most_age
       )
     }
 

--- a/R/popReconstruct_fit.R
+++ b/R/popReconstruct_fit.R
@@ -519,6 +519,7 @@ popReconstruct_fit <- function(inputs,
       map <- map[names(map) %in% names(input_parameters)]
     }
 
+    input_data$estimate_survival <- "survival" %in% settings$estimated_parameters
     input_data$estimate_net_migration <- "net_migration" %in% settings$estimated_parameters
 
     # make objective function

--- a/inst/stan/popReconstruct.stan
+++ b/inst/stan/popReconstruct.stan
@@ -1,11 +1,9 @@
 functions {
   matrix bounded_inv_logit(matrix x, int domain_lower, int domain_upper) {
     matrix[rows(x), cols(x)] result;
-    real scalar;
 
     result = exp(x) ./ (1 + exp(x));
-    scalar = (domain_upper - domain_lower) + domain_lower;
-    result = result * scalar;
+    result = (result * (domain_upper - domain_lower)) + domain_lower;
     return(result);
   }
 

--- a/src/TMB/popReconstruct.hpp
+++ b/src/TMB/popReconstruct.hpp
@@ -20,9 +20,8 @@ template<class Type>
 array<Type> bounded_inv_logit(array<Type> x, int domain_lower, int domain_upper) {
 
   array<Type> result(x.dim);
-  int scalar = (domain_upper - domain_lower) + domain_lower;
   result = exp(x) / (1 + exp(x));
-  result = result * scalar;
+  result = (result * (domain_upper - domain_lower)) + domain_lower;
   return result;
 }
 

--- a/src/TMB/popReconstruct.hpp
+++ b/src/TMB/popReconstruct.hpp
@@ -360,6 +360,7 @@ Type popReconstruct(objective_function<Type>* obj) {
     }
     spline_offset_log_baseline.col(s) = B_a_baseline * sex_specific_offset_log_baseline_matrix;
 
+    // calculate either the survival spline offsets or mx & ax spline offsets
     if (estimate_survival) {
       for (int y = 0; y < N_k_t_survival; y++) {
         for (int a = 0; a < N_k_a_survival; a++) {
@@ -388,6 +389,7 @@ Type popReconstruct(objective_function<Type>* obj) {
       spline_offset_log_terminal_ax.col(s) = sex_specific_offset_log_terminal_ax_matrix * B_t_terminal_ax.transpose();
     }
 
+    // calculate either the net migration spline offsets or immigration & emigration spline offsets
     if (estimate_net_migration) {
       for (int y = 0; y < N_k_t_net_migration; y++) {
         for (int a = 0; a < N_k_a_net_migration; a++) {

--- a/tests/testthat/test-popReconstruct.R
+++ b/tests/testthat/test-popReconstruct.R
@@ -1,3 +1,5 @@
+set.seed(1)
+
 settings = list(
   years = seq(1960, 2000, 5),
   sexes = c("female"),
@@ -231,6 +233,14 @@ testthat::test_that("sampling from popReconstruct (mx & ax) model prior works", 
     software = "stan",
     chains = 1, warmup = 100, iter = 200, thin = 2, seed = 3
   )
+
+  test_fit(
+    inputs = new_inputs,
+    data = demCore::burkina_faso_data,
+    hyperparameters = new_hyperparameters,
+    settings = settings,
+    software = "tmb"
+  )
 })
 
 testthat::test_that("sampling from popReconstruct (mx) model prior works", {
@@ -258,5 +268,12 @@ testthat::test_that("sampling from popReconstruct (mx) model prior works", {
     chains = 1, warmup = 100, iter = 200, thin = 2, seed = 3
   )
 
+  test_fit(
+    inputs = new_inputs,
+    data = demCore::burkina_faso_data,
+    hyperparameters = new_hyperparameters,
+    settings = new_settings,
+    software = "tmb"
+  )
 })
 


### PR DESCRIPTION
## Describe changes

Adds additional flexibility to the popReconstruct model to estimate 'mx' and 'ax' instead of the survivorship ratio. This PR only includes this flexibility for fitting the model in tmb. This was previously implemented for the stan model in #23.

## What issues are related

Partially implements #21

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Packages Repositories

* [X] Have you read the [contributing guidelines](https://github.com/ihmeuw-demographics/packageTemplate/wiki#guide-to-r-package-development) for `ihmeuw-demographics` R packages?
* [X] Have you successfully run `devtools::check()` locally?
* [X] Have you updated or added function (and vignette if applicable) documentation? Did you update the 'man' and 'NAMESPACE' files with `devtools::document()`?
* [X] Have you added in tests for the changes included in the PR?
* [X] Do the changes follow the `ihmeuw-demographics` [code style](https://github.com/ihmeuw-demographics/packageTemplate/wiki/Code-style-guide)?
* [] Do the changes need to be immediately included in a new build of [`docker-base`](https://github.com/ihmeuw-demographics/docker-base) or [`docker-internal`](https://github.com/ihmeuw-demographics/docker-internal)? If so follow directions in those repositories to rebuild and redeploy the images.
* [ ] Do the changes require updates to other repositories which use this package? If yes, make the necessary updates in those repos, and consider integration tests for those repositories.

## Details of PR

This actually doesn't pass the 2 tests added because some of the draws from the posterior have mx, ax combinations that lead to nSx draws above 1. I think its best to review this PR first and make a separate issue to add flexibility to the function to extract draws from the posterior since we aren't even using the tmb version right now. Will need to implement something similar to `popReconstruct_prior_draws` function where we sample X draws at a time and drop any draws where transformed parameters don't meet certain constraints (like negative population or survivorship outside 0 and 1).